### PR TITLE
Include numeric names for globals

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "publisher": "revng",
     "displayName": "LLVM IR Language Support",
     "description": "LLVM IR language support for Visual Studio Code",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "engines": {
         "vscode": "^1.63.0"
     },

--- a/src/test/data.ll
+++ b/src/test/data.ll
@@ -4,6 +4,7 @@ target triple = "x86_64-pc-linux-gnu"
 @.fizz = private unnamed_addr constant [6 x i8] c"Fizz \00", align 1
 @.buzz = private unnamed_addr constant [6 x i8] c"Buzz \00", align 1
 @.nl = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
+@1 = internal constant [13 x i8] "Hello world!\00"
 
 declare noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr
 

--- a/src/test/lsp_model_provider.test.ts
+++ b/src/test/lsp_model_provider.test.ts
@@ -46,7 +46,14 @@ describe("LspModelProvider", () => {
     });
 
     test("Checking globals", () => {
-        expect(Array.from(result.global.values.keys())).toEqual(["@.fmtstr", "@.fizz", "@.buzz", "@.nl", "@printf"]);
+        expect(Array.from(result.global.values.keys())).toEqual([
+            "@.fmtstr",
+            "@.fizz",
+            "@.buzz",
+            "@.nl",
+            "@1",
+            "@printf",
+        ]);
     });
 
     test("Checking locals in @main", () => {

--- a/src/web/llvmir/regexp.ts
+++ b/src/web/llvmir/regexp.ts
@@ -16,7 +16,7 @@ export namespace Regexp {
     /**
      * Matches global identifiers
      */
-    const globalVarFrag = `@${identifierFrag}`;
+    const globalVarFrag = `@(${identifierFrag}|\\d+)`;
 
     /**
      * Matches local identifiers


### PR DESCRIPTION
Allows the detection of anonymous globals (e.g. `@172`)